### PR TITLE
Doc for specialized LieTensors

### DIFF
--- a/pypose/lietensor/utils.py
+++ b/pypose/lietensor/utils.py
@@ -23,9 +23,9 @@ def _LieTensor_wrapper_add_docstr(wrapper: functools.partial, embedding_doc):
             from ':obj:`int`...', which defines tensor shape.
 
             The shape of :obj:`Tensor` object must be `(*, {type_dim})`,
-            where `*` is zero or more batch dimensions (the
-            :obj:`~LieTensor.lshape` of this LieTensor). Otherwise error will
-            be thrown.
+            where `*` is empty, one, or more batched dimensions (the
+            :obj:`~LieTensor.lshape` of this LieTensor), otherwise error will
+            be raised.
 
     {embedding_doc}
 


### PR DESCRIPTION
Add explanation of storage and usage for specialized LieTensors: SO3, so3, SE3, se3, RxSO3, rxso3, Sim3, sim3.