### PR TITLE
CI build for pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,14 @@ jobs:
             curl -X POST -H "Authorization: token ${PYPOSE_ORG_AUTH}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/pypose/pypose.github.io/dispatches \
-            -d "{\"event_type\": \"circle-ci-build\", \"client_payload\": {\"job_num\": \"${CIRCLE_BUILD_NUM}\", \"file_name\": \"docs.tar.gz\"}}"
+            -d "{
+              \"event_type\": \"circle-ci-build\",
+              \"client_payload\": {
+                \"job_num\": \"${CIRCLE_BUILD_NUM}\",
+                \"file_name\": \"docs.tar.gz\",
+                \"pr_num\": \"${CIRCLE_PR_NUMBER}\"
+              }
+            }"
 
 
 ##############################################################################
@@ -137,9 +144,6 @@ workflows:
   build:
     jobs:
       - linux_build_wheel:
-          filters:
-            branches:
-              only: [main]
           cuda_version: "11.3.1"
           torch_version: "1.11.0"
           python_version: "3.8"


### PR DESCRIPTION
This PR allows CircleCI to build pull requests as a sanity check.

- A build is triggered every time a pull request is open or committed to.  To save quota, only branches linked to a pull request will be able to trigger build.
- Built documentation of pull requests will be accessible under e.g. [pypose.org/docs/preview/pr/67](https://pypose.org/docs/preview/pr/67). pypose.org/docs now only hosts documentation built from `main`.