### PR TITLE
Add redirection for switching between doc versions

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,42 @@
+{% extends "!layout.html" %}
+<link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
+
+{% block extrahead %}
+{% if release == "main" %}
+<!--
+  Search engines should not index the master version of documentation.
+  Stable documentation are built without release == 'main'.
+-->
+<meta name="robots" content="noindex">
+{% endif %}
+{{ super() }}
+{% endblock %}
+
+{% block menu %}
+{% if release == "main" %}
+<div>
+  <a style="color:#F05732" href="{{ theme_canonical_url }}{{ pagename }}.html">
+    You are viewing unstable developer preview docs.
+    Click here to view docs for latest stable release.
+  </a>
+</div>
+{% endif %}
+{{ super() }}
+{% endblock %}
+
+{% block sidebartitle %}
+    <div class="version">
+      <a href='https://pypose.org/docs/versions.html'>{{ version }} &#x25BC</a>
+    </div>
+    {% include "searchbox.html" %}
+{% endblock %}
+
+
+{% block footer %}
+{{ super() }}
+<script script type="text/javascript">
+  var collapsedSections = ['Developer Notes', 'Language Bindings', 'Libraries', 'Community'];
+</script>
+
+<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,9 @@ project = 'PyPose'
 copyright = '2022, PyPose Contributors'
 author = 'PyPose Contributors'
 
+# set by release script
+RELEASE = os.environ.get('RELEASE', False)
+
 # The full version, including alpha/beta/rc tags
 def find_version(file_path: str) -> str:
     version_file = open(file_path).read()
@@ -33,6 +36,11 @@ def find_version(file_path: str) -> str:
 
 version = find_version(os.path.join(proj_root, "pypose/_version.py"))
 
+release = "main"
+if RELEASE:
+    version = '.'.join(version.split('.')[:2])
+    html_title = " ".join((project, version, "documentation"))
+    release = version
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This PR creates a button on the left of each doc page that allows the selection of versions. Layout file is lifted from [pytorch](https://github.com/pytorch/pytorch/blob/41e2611e6a3f53f549ad27585a58ba7f7c71594a/docs/source/_templates/layout.html).