### PR TITLE
Update dev.txt

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==5.0.0
 sphinxcontrib.katex
 sphinx_rtd_theme
 pypose_sphinx_theme


### PR DESCRIPTION
higher version of sphinx removes js dependencies, which causes jquery.js to be missing on server side https://github.com/sphinx-doc/sphinx/issues/10070

However, the Pytorch templates isn't up-to-date adapting this change.

To solve this problem, need to explicitly specify a version, like:
https://github.com/pytorch/pytorch/blob/master/docs/requirements.txt
https://github.com/open-mmlab/mmcv/blob/master/requirements/docs.txt

With this change, the cookie reminder bar is working properly, as well as readthedoc flyover menu
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/24406547/224412970-7f3b2350-c0ce-4670-9dfc-634240453a28.png">

<img width="329" alt="image" src="https://user-images.githubusercontent.com/24406547/224413066-ef0aa496-88f9-4156-a441-b23bbf59a2db.png">
