### PR TITLE
fix a bug in kernel.py

### DIFF
--- a/pypose/optim/kernel.py
+++ b/pypose/optim/kernel.py
@@ -255,7 +255,7 @@ class Tolerant(nn.Module):
         '''
         assert torch.all(input >= 0), 'input has to be non-negative'
         part1 = (1 + ((input-self.a) / self.b).exp()).log()
-        part2 = (1 + torch.tensor(-self.a / self.b).exp())
+        part2 = (1 + torch.tensor(-self.a / self.b).exp()).log()
         return self.b * part1 - self.b * part2
 
 
@@ -296,4 +296,3 @@ class Scale(nn.Module):
             input (torch.Tensor): the input tensor (non-negative).
         '''
         return self.delta * input
-

--- a/pypose/optim/kernel.py
+++ b/pypose/optim/kernel.py
@@ -245,7 +245,6 @@ class Tolerant(nn.Module):
         super().__init__()
         assert a > 0, ValueError("a has to be positive: {}".format(a))
         assert b < 0, ValueError("b has to be negative: {}".format(b))
-        self.offset = b * math.log((1 + math.exp(-a / b)))
         self.a, self.b = a, b
 
     def forward(self, input: Tensor) -> Tensor:
@@ -255,7 +254,8 @@ class Tolerant(nn.Module):
         '''
         assert torch.all(input >= 0), 'input has to be non-negative'
         res = self.b * (1 + ((input-self.a) / self.b).exp()).log()
-        return res - self.offset
+        offset = self.b * math.log((1 + math.exp(-self.a / self.b)))
+        return res - offset
 
 
 class Scale(nn.Module):

--- a/pypose/optim/kernel.py
+++ b/pypose/optim/kernel.py
@@ -255,7 +255,7 @@ class Tolerant(nn.Module):
         '''
         assert torch.all(input >= 0), 'input has to be non-negative'
         part1 = (1 + ((input-self.a) / self.b).exp()).log()
-        part2 = (1 + (-self.a / self.b).exp())
+        part2 = (1 + torch.tensor(-self.a / self.b).exp())
         return self.b * part1 - self.b * part2
 
 

--- a/pypose/optim/kernel.py
+++ b/pypose/optim/kernel.py
@@ -253,9 +253,9 @@ class Tolerant(nn.Module):
             input (torch.Tensor): the input tensor (non-negative).
         '''
         assert torch.all(input >= 0), 'input has to be non-negative'
-        res = self.b * (1 + ((input-self.a) / self.b).exp()).log()
-        offset = self.b * math.log((1 + math.exp(-self.a / self.b)))
-        return res - offset
+        result = self.b * (1 + ((input-self.a) / self.b).exp()).log()
+        offset = self.b * math.log((1 + math.exp(-self.a / self.b))) # constant, no grad.
+        return result - offset
 
 
 class Scale(nn.Module):

--- a/pypose/optim/kernel.py
+++ b/pypose/optim/kernel.py
@@ -1,4 +1,4 @@
-import torch
+import torch, math
 from torch import nn, Tensor
 
 
@@ -245,8 +245,8 @@ class Tolerant(nn.Module):
         super().__init__()
         assert a > 0, ValueError("a has to be positive: {}".format(a))
         assert b < 0, ValueError("b has to be negative: {}".format(b))
-        self.a = a
-        self.b = b
+        self.offset = b * math.log((1 + math.exp(-a / b)))
+        self.a, self.b = a, b
 
     def forward(self, input: Tensor) -> Tensor:
         '''
@@ -254,9 +254,8 @@ class Tolerant(nn.Module):
             input (torch.Tensor): the input tensor (non-negative).
         '''
         assert torch.all(input >= 0), 'input has to be non-negative'
-        part1 = (1 + ((input-self.a) / self.b).exp()).log()
-        part2 = (1 + torch.tensor(-self.a / self.b).exp()).log()
-        return self.b * part1 - self.b * part2
+        res = self.b * (1 + ((input-self.a) / self.b).exp()).log()
+        return res - self.offset
 
 
 class Scale(nn.Module):


### PR DESCRIPTION
In the Tolerant class, both `self.a` and `self.b` are initialized as floats. This will cause a error when executing the forward method `part2 = (1 + torch.tensor(-self.a / self.b).exp())` line, as shown below:
```
    part2 = (1 + (-self.a / self.b).exp())
AttributeError: 'float' object has no attribute 'exp'
```
To resolve this issue, I have changed the data type of `-self.a / self.b` from float to torch.tensor. This should fix the bug.
