### PR TITLE
Make lietensor type and operations preserved under `vmap`

### DIFF
--- a/pypose/lietensor/lietensor.py
+++ b/pypose/lietensor/lietensor.py
@@ -1228,7 +1228,9 @@ def retain_ltype():
     TO_BE_WRAPPED = {
         torch.autograd.forward_ad.make_dual,
         torch._functorch.eager_transforms._wrap_tensor_for_grad,
+        torch._functorch.vmap._add_batch_dim,
     }
+    torch._functorch.vmap._add_batch_dim.__module__ = 'torch._functorch.vmap'
 
     def wrap_function(func):
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
title. The strategy follow the previous https://github.com/pypose/pypose/pull/262 