### PR TITLE
assert x does not contain nan in CG solver

### DIFF
--- a/pypose/optim/solver.py
+++ b/pypose/optim/solver.py
@@ -327,4 +327,7 @@ class CG(nn.Module):
             r -= alpha.unsqueeze(-1)*q
             rho_prev = rho_cur
 
+        assert not torch.any(torch.isnan(x)), \
+            'Conjugate Gradient Solver Failed. Check your matrix (may not be Symmetric Positive Definite)'
+
         return x


### PR DESCRIPTION
Currently, CG will silently return `x` even if it contains `nan`, which may hide numeric instability issue.