### PR TITLE
fix `cumops` where left arg is actually right.

### DIFF
--- a/pypose/basics/ops.py
+++ b/pypose/basics/ops.py
@@ -36,18 +36,24 @@ def cumops_(input, dim, ops):
     return v
 
 
-def cummul_(input, dim):
+def cummul_(input, dim, left = True):
     r'''
         Inplace version of :meth:`pypose.cummul`
     '''
-    return cumops_(input, dim, lambda a, b : a * b)
+    if left:
+        return cumops_(input, dim, lambda a, b : b * a)
+    else:
+        return cumops_(input, dim, lambda a, b : a * b)
 
 
-def cumprod_(input, dim):
+def cumprod_(input, dim, left = True):
     r'''
         Inplace version of :meth:`pypose.cumprod`
     '''
-    return cumops_(input, dim, lambda a, b : a @ b)
+    if left:
+        return cumops_(input, dim, lambda a, b : b @ a)
+    else:
+        return cumops_(input, dim, lambda a, b : a @ b)
 
 
 def cumops(input, dim, ops):
@@ -138,9 +144,9 @@ def cummul(input, dim, left = True):
                 [ 2.0905e-04,  5.2031e-01,  8.4301e-01, -1.3642e-01]]])
     """
     if left:
-        return cumops(input, dim, lambda a, b : a * b)
-    else:
         return cumops(input, dim, lambda a, b : b * a)
+    else:
+        return cumops(input, dim, lambda a, b : a * b)
 
 
 def cumprod(input, dim, left = True):
@@ -192,6 +198,6 @@ def cumprod(input, dim, left = True):
                 [ 0.7515, -0.1920,  0.5072,  0.3758]]])
     """
     if left:
-        return cumops(input, dim, lambda a, b : a @ b)
-    else:
         return cumops(input, dim, lambda a, b : b @ a)
+    else:
+        return cumops(input, dim, lambda a, b : a @ b)

--- a/pypose/basics/ops.py
+++ b/pypose/basics/ops.py
@@ -32,7 +32,7 @@ def cumops_(input, dim, ops):
     assert dim != -1 or dim != v.shape[-1], "Invalid dim"
     for i in torch.pow(2, torch.arange(math.log2(L)+1, device=v.device, dtype=torch.int64)):
         index = torch.arange(i, L, device=v.device, dtype=torch.int64)
-        v.index_copy_(dim, index, ops(v.index_select(dim, index), v.index_select(dim, index-i)))
+        v.index_copy_(dim, index, ops(v.index_select(dim, index-i), v.index_select(dim, index)))
     return v
 
 

--- a/pypose/basics/ops.py
+++ b/pypose/basics/ops.py
@@ -82,12 +82,13 @@ def cumops(input, dim, ops):
           :math:`N` is the LieTensor size along the :obj:`dim` dimension.
 
     Examples:
+        >>> # The following operations are equivalent.
         >>> input = pp.randn_SE3(2)
-        >>> input.cumprod(dim = 0)
+        >>> input.cumprod(dim = 0, left=True)
         SE3Type LieTensor:
         tensor([[-0.6466,  0.2956,  2.4055, -0.4428,  0.1893,  0.3933,  0.7833],
                 [ 1.2711,  1.2020,  0.0651, -0.0685,  0.6732,  0.7331, -0.0685]])
-        >>> pp.cumops(input, 0, lambda a, b : a @ b)
+        >>> pp.cumops(input, 0, lambda a, b : b @ a) # Left multiplication
         SE3Type LieTensor:
         tensor([[-0.6466,  0.2956,  2.4055, -0.4428,  0.1893,  0.3933,  0.7833],
                 [ 1.2711,  1.2020,  0.0651, -0.0685,  0.6732,  0.7331, -0.0685]])

--- a/pypose/lietensor/lietensor.py
+++ b/pypose/lietensor/lietensor.py
@@ -156,8 +156,8 @@ class LieType:
         return cumops(X, dim, ops)
 
     @classmethod
-    def cummul(self, X, dim):
-        return cummul(X, dim)
+    def cummul(self, X, dim, left = True):
+        return cummul(X, dim, left)
 
     @classmethod
     def cumprod(self, X, dim, left = True):
@@ -168,12 +168,12 @@ class LieType:
         return cumops_(X, dim, ops)
 
     @classmethod
-    def cummul_(self, X, dim):
-        return cummul_(X, dim)
+    def cummul_(self, X, dim, left = True):
+        return cummul_(X, dim, left)
 
     @classmethod
-    def cumprod_(self, X, dim):
-        return cumprod_(X, dim)
+    def cumprod_(self, X, dim, left = True):
+        return cumprod_(X, dim, left)
 
 
 class SO3Type(LieType):
@@ -1152,11 +1152,11 @@ class LieTensor(torch.Tensor):
         """
         return self.ltype.cumops(self, dim, ops)
 
-    def cummul(self, dim):
+    def cummul(self, dim, left = True):
         r"""
         See :func:`pypose.cummul`
         """
-        return self.ltype.cummul(self, dim)
+        return self.ltype.cummul(self, dim, left)
 
     def cumprod(self, dim, left = True):
         r"""
@@ -1170,17 +1170,17 @@ class LieTensor(torch.Tensor):
         """
         return self.ltype.cumops_(self, dim, ops)
 
-    def cummul_(self, dim):
+    def cummul_(self, dim, left = True):
         r"""
         Inplace version of :func:`pypose.cummul`
         """
-        return self.ltype.cummul_(self, dim)
+        return self.ltype.cummul_(self, dim, left)
 
-    def cumprod_(self, dim):
+    def cumprod_(self, dim, left = True):
         r"""
         Inplace version of :func:`pypose.cumprod`
         """
-        return self.ltype.cumprod_(self, dim)
+        return self.ltype.cumprod_(self, dim, left)
 
 
 class Parameter(LieTensor, nn.Parameter):

--- a/pypose/module/imu_preintegrator.py
+++ b/pypose/module/imu_preintegrator.py
@@ -357,7 +357,7 @@ class IMUPreintegrator(nn.Module):
         B, F = dt.shape[:2]
         dr =  so3(gyro*dt).Exp()
         w = torch.cat([identity_SO3(B, 1, dtype=dt.dtype, device=dt.device), dr], dim=1)
-        incre_r = cumprod(w, dim = 1, left=True)
+        incre_r = cumprod(w, dim = 1, left=False)
 
         if isinstance(rot, LieTensor):
             a = acc - rot.Inv() @ self.gravity
@@ -457,7 +457,7 @@ class IMUPreintegrator(nn.Module):
         B_cov = torch.einsum('...xy,...t -> ...xy', Bg @ Cg @ Bg.mT + Ba @ Ca @ Ba.mT, 1/cov_input['dt'])
         B_cov = torch.cat([init_cov[:,None,...], B_cov], dim=1)
 
-        A_left_cum = cumprod(A.flip([1]), dim=1, left=False).flip([1]) # cum from An to I, then flip
+        A_left_cum = cumprod(A.flip([1]), dim=1).flip([1]) # cum from An to I, then flip
         A_right_cum = A_left_cum.mT
         cov = torch.sum(A_left_cum @ B_cov @ A_right_cum, dim=1)
         return {'cov': cov, 'Rij': cov_input['Rij'][..., -1:, :]}

--- a/tests/basics/test_ops.py
+++ b/tests/basics/test_ops.py
@@ -12,7 +12,7 @@ class TestOps:
             pm = torch.tensor([1, 1, -1], dtype=dtype, device=self.device)
             assert torch.equal(x, pm), "Results incorrect."
 
-    def text_cum(self):
+    def test_cum(self):
         N = 4
         x = pp.randn_SO3(N, dtype=torch.float64)
 
@@ -59,4 +59,4 @@ class TestOps:
 if __name__ == '__main__':
     test = TestOps()
     test.test_pm()
-    test.text_cum()
+    test.test_cum()

--- a/tests/basics/test_ops.py
+++ b/tests/basics/test_ops.py
@@ -12,7 +12,51 @@ class TestOps:
             pm = torch.tensor([1, 1, -1], dtype=dtype, device=self.device)
             assert torch.equal(x, pm), "Results incorrect."
 
+    def text_cum(self):
+        N = 4
+        x = pp.randn_SO3(N, dtype=torch.float64)
+
+        O1 = x[3] @ x[2] @ x[1] @ x[0]
+        O2 = pp.cumprod(x, dim=0, left=True)[N-1]
+        pp.testing.assert_close(O1, O2, rtol=1e-4, atol=1e-4)
+
+        O3 = x[0] @ x[1] @ x[2] @ x[3]
+        O4 = pp.cumprod(x, dim=0, left=False)[N-1]
+        pp.testing.assert_close(O3, O4, rtol=1e-4, atol=1e-4)
+
+        O5 = x[3] @ x[2] @ x[1] @ x[0]
+        O6 = pp.cummul(x, dim=0, left=True)[N-1]
+        pp.testing.assert_close(O5, O6, rtol=1e-4, atol=1e-4)
+
+        O7 = x[0] @ x[1] @ x[2] @ x[3]
+        O8 = pp.cummul(x, dim=0, left=False)[N-1]
+        pp.testing.assert_close(O7, O8, rtol=1e-4, atol=1e-4)
+
+        y = x.clone()
+        pp.cumprod_(y, dim=0, left=True)
+        pp.testing.assert_close(O1, y[N-1], rtol=1e-4, atol=1e-4)
+
+        z = x.clone()
+        pp.cumprod_(z, dim=0, left=False)
+        pp.testing.assert_close(O3, z[N-1], rtol=1e-4, atol=1e-4)
+
+        y = x.clone()
+        pp.cummul_(y, dim=0, left=True)
+        pp.testing.assert_close(O1, y[N-1], rtol=1e-4, atol=1e-4)
+
+        z = x.clone()
+        pp.cummul_(z, dim=0, left=False)
+        pp.testing.assert_close(O3, z[N-1], rtol=1e-4, atol=1e-4)
+
+        left = lambda a, b: b @ a
+        O9 = pp.cumops(x, dim=0, ops=left)[N-1]
+        pp.testing.assert_close(O1, O9, rtol=1e-4, atol=1e-4)
+
+        right = lambda a, b: a @ b
+        OX = pp.cumops(x, dim=0, ops=right)[N-1]
+        pp.testing.assert_close(O3, OX, rtol=1e-4, atol=1e-4)
 
 if __name__ == '__main__':
     test = TestOps()
     test.test_pm()
+    test.text_cum()


### PR DESCRIPTION
Assume a sequence 'x1, x2, x3', left cumulative multiplication should be "x3 @ x2 @ x1", where current implementation is "x1 @ x2 @ x3" `for cumops`
This pull request corrects this issue and **doesn't affect** existing implementation that calls the following functions: `cumprod, cumprod_, cummul, cummul_`. To clarify, simply use `cumprod(input, left=True)`.

- The following operations are equivalent.
```python
>>> input = pp.randn_SE3(2)
>>> input.cumprod(dim = 0, left=True)
SE3Type LieTensor:
tensor([[-0.6466,  0.2956,  2.4055, -0.4428,  0.1893,  0.3933,  0.7833],
        [ 1.2711,  1.2020,  0.0651, -0.0685,  0.6732,  0.7331, -0.0685]])
>>> pp.cumops(input, 0, lambda a, b : b @ a) # Left multiplication
SE3Type LieTensor:
tensor([[-0.6466,  0.2956,  2.4055, -0.4428,  0.1893,  0.3933,  0.7833],
        [ 1.2711,  1.2020,  0.0651, -0.0685,  0.6732,  0.7331, -0.0685]])
```


