### PR TITLE
add quat2unit

### DIFF
--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -20,6 +20,7 @@ Convert
     euler
     scale
     matrix
+    quat2unit
     cart2homo
     homo2cart
     point2pixel

--- a/pypose/__init__.py
+++ b/pypose/__init__.py
@@ -10,7 +10,7 @@ from .lietensor import identity_Sim3, identity_sim3, identity_RxSO3, identity_rx
 from .lietensor import add, add_, mul, Exp, Log, Inv, Mul, Retr, Act, Adj, AdjT, Jinvp, Jr
 from .lietensor import SO3_type, so3_type, SE3_type, se3_type
 from .lietensor import Sim3_type, sim3_type, RxSO3_type, rxso3_type
-from .lietensor import tensor, translation, rotation, scale, matrix, euler
+from .lietensor import tensor, translation, rotation, scale, matrix, euler, quat2unit
 from .lietensor import mat2SO3, mat2SE3, mat2Sim3, mat2RxSO3, from_matrix, matrix, euler2SO3, vec2skew
 from .lietensor.lietensor import retain_ltype
 from . import func

--- a/pypose/lietensor/__init__.py
+++ b/pypose/lietensor/__init__.py
@@ -9,5 +9,5 @@ from .utils import identity_Sim3, identity_sim3, identity_RxSO3, identity_rxso3
 from .utils import SO3, so3, SE3, se3, Sim3, sim3, RxSO3, rxso3
 from .utils import Exp, Log, Inv, Mul, Retr, Act, Adj, AdjT, Jinvp, Jr
 from .basics import vec2skew, add, add_, mul
-from .convert import tensor, translation, rotation, scale, matrix, euler
+from .convert import tensor, translation, rotation, scale, matrix, euler, quat2unit
 from .convert import mat2SO3, mat2SE3, mat2Sim3, mat2RxSO3, from_matrix, matrix, euler2SO3

--- a/pypose/lietensor/convert.py
+++ b/pypose/lietensor/convert.py
@@ -832,7 +832,7 @@ def quat2unit(input: LieTensor, eps=1e-12) -> LieTensor:
     r'''
     Normalize the quaternion part of a ``LieTensor``, which has to be a Lie group.
     If input is a not a Lie group, then do nothing and return the input.
-    If the quaternion parts are zeros, then initilize identity quaternions.
+    If the quaternion parts contain pure zeros, then raise an error.
 
     The quaternion parts :math:`v` are normalized as
 
@@ -855,8 +855,8 @@ def quat2unit(input: LieTensor, eps=1e-12) -> LieTensor:
         elif input.ltype in [SE3_type, Sim3_type]:
             data[..., 3:7] = normalize(data[..., 3:7], p=2, dim=-1, eps=eps)
         output = LieTensor(data, ltype=input.ltype)
-        if torch.norm(output.rotation()) < eps:
-            output.rotation().identity_()
+        if (output.rotation().norm(p=2, dim=-1) < eps).any():
+            raise ValueError("Detected zero quaternions, which cannot be normalized.")
         return output
     else:
         warnings.warn("Input is not Lie group, doing thing and returning input..")

--- a/pypose/lietensor/convert.py
+++ b/pypose/lietensor/convert.py
@@ -830,8 +830,8 @@ def euler(inputs, eps=2e-4):
 
 def quat2unit(input: LieTensor, eps=1e-12) -> LieTensor:
     r'''
-    Normalize the quaternion part of a ``LieTensor``, which has to be a Lie Group.
-    If input is a Lie algebra, then do nothing and return the input tensor.
+    Normalize the quaternion part of a ``LieTensor``, which has to be a Lie group.
+    If input is a not a Lie group, then do nothing and return the input.
     If the quaternion parts are zeros, then initilize identity quaternions.
 
     The quaternion parts :math:`v` are normalized as
@@ -848,11 +848,7 @@ def quat2unit(input: LieTensor, eps=1e-12) -> LieTensor:
     Return:
         :obj:`LieTensor`: the output LieTensor.
     '''
-    assert isinstance(input, LieTensor), "Input should be a LieTensor"
-
-    if input.ltype in liealgebra:
-        return input
-    elif input.ltype in liegroup:
+    if isinstance(input, LieTensor) and (input.ltype in liegroup):
         data = input.tensor()
         if input.ltype in [SO3_type, RxSO3_type]:
             data[..., :4] = normalize(data[..., :4], p=2, dim=-1, eps=eps)
@@ -863,4 +859,5 @@ def quat2unit(input: LieTensor, eps=1e-12) -> LieTensor:
             output.rotation().identity_()
         return output
     else:
-        raise "LieType of Input LieTensor not recognized."
+        warnings.warn("Input is not Lie group, doing thing and returning input..")
+        return input

--- a/pypose/lietensor/convert.py
+++ b/pypose/lietensor/convert.py
@@ -832,7 +832,7 @@ def quat2unit(input: LieTensor, eps=1e-12) -> LieTensor:
     r'''
     Normalize the quaternion part of a ``LieTensor``, which has to be a Lie Group.
     If input is a Lie algebra, then do nothing and return the input tensor.
-    If the quaternion parts are zeros, then initilize unit quaternions.
+    If the quaternion parts are zeros, then initilize identity quaternions.
 
     The quaternion parts :math:`v` are normalized as
 

--- a/pypose/lietensor/lietensor.py
+++ b/pypose/lietensor/lietensor.py
@@ -740,7 +740,8 @@ SO3_type, so3_type = SO3Type(), so3Type()
 SE3_type, se3_type = SE3Type(), se3Type()
 Sim3_type, sim3_type = Sim3Type(), sim3Type()
 RxSO3_type, rxso3_type = RxSO3Type(), rxso3Type()
-
+liegroup = [SO3_type, SE3_type, Sim3_type, RxSO3_type]
+liealgebra = [so3_type, se3_type, sim3_type, rxso3_type]
 
 class LieTensor(torch.Tensor):
     r""" A sub-class of :obj:`torch.Tensor` to represent Lie Algebra and Lie Group.

--- a/tests/basics/test_ops.py
+++ b/tests/basics/test_ops.py
@@ -56,7 +56,31 @@ class TestOps:
         OX = pp.cumops(x, dim=0, ops=right)[N-1]
         pp.testing.assert_close(O3, OX, rtol=1e-4, atol=1e-4)
 
+    def test_quat2unit(self):
+        x = pp.randn_SE3(2, 2)
+        pp.quat2unit(x)
+
+        x = pp.SE3([0, 0, 0, 0, 0, 0, 0.5])
+        pp.quat2unit(x)
+
+        x = pp.SE3([0, 0, 0, 0, 0, 0, 0])
+        pp.quat2unit(x)
+
+        x = pp.SO3([0, 0, 0, 0])
+        pp.quat2unit(x)
+
+        x = pp.SO3([0, 0, 0, 0.5])
+        pp.quat2unit(x)
+
+        x = pp.Sim3([0, 0, 0, 0, 0, 0, 0.5, 0.2])
+        pp.quat2unit(x)
+
+        x = pp.RxSO3([0, 0.5, 0, 0.1, 0.2])
+        pp.quat2unit(x)
+
+
 if __name__ == '__main__':
     test = TestOps()
     test.test_pm()
     test.test_cum()
+    test.test_quat2unit()

--- a/tests/basics/test_ops.py
+++ b/tests/basics/test_ops.py
@@ -58,25 +58,28 @@ class TestOps:
 
     def test_quat2unit(self):
         x = pp.randn_SE3(2, 2)
-        pp.quat2unit(x)
+        y = pp.quat2unit(x)
+        print(y)
 
         x = pp.SE3([0, 0, 0, 0, 0, 0, 0.5])
-        pp.quat2unit(x)
-
-        x = pp.SE3([0, 0, 0, 0, 0, 0, 0])
-        pp.quat2unit(x)
-
-        x = pp.SO3([0, 0, 0, 0])
-        pp.quat2unit(x)
+        y = pp.quat2unit(x)
+        print(y)
 
         x = pp.SO3([0, 0, 0, 0.5])
-        pp.quat2unit(x)
+        y = pp.quat2unit(x)
+        print(y)
 
         x = pp.Sim3([0, 0, 0, 0, 0, 0, 0.5, 0.2])
-        pp.quat2unit(x)
+        y = pp.quat2unit(x)
+        print(y)
 
         x = pp.RxSO3([0, 0.5, 0, 0.1, 0.2])
-        pp.quat2unit(x)
+        y = pp.quat2unit(x)
+        print(y)
+
+        x = pp.RxSO3([[0, 0.5, 0, 0.1, 0.2], [0, 0.2, 0, 0, 0.2]])
+        y = pp.quat2unit(x)
+        print(y)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
add the function of `quat2unit` to normalize the quaternion part of a LieTensor, addressing #346.