### PR TITLE
Fixed mpc example bugs based on pr 369. Thanks @andreaostuni

### DIFF
--- a/examples/module/mpc/cartpole.py
+++ b/examples/module/mpc/cartpole.py
@@ -19,7 +19,7 @@ class CartPole(pp.module.NLS):
             self.totalMass = self.cartmass + self.polemass
 
         def state_transition(self, state, input, t=None):
-            x, xDot, theta, thetaDot = state.squeeze()
+            x, xDot, theta, thetaDot = state.clone().squeeze()
             force = input.squeeze()
             costheta = torch.cos(theta)
             sintheta = torch.sin(theta)

--- a/pypose/module/dynamics.py
+++ b/pypose/module/dynamics.py
@@ -210,7 +210,7 @@ class LTI(System):
         Returns:
             ``Tensor``: The state the system in next time step.
         '''
-        z = bmv(self.A, state) + bmv(self.B, input)
+        z = bmv(self.A, state.clone()) + bmv(self.B, input)
         return z if self.c1 is None else z + self.c1
 
     def observation(self, state, input):


### PR DESCRIPTION
Adding `.clone()` to the variable _state_ in the state transition function to resolve variable _state_ computational graph version conflicts during backpropagation in training.