### PR TITLE
Change scheduler to start from step 1 instead of 0

### DIFF
--- a/pypose/optim/scheduler.py
+++ b/pypose/optim/scheduler.py
@@ -151,7 +151,9 @@ class StopOnPlateau(_Scheduler):
                 print("StopOnPlateau: Maximum patience steps reached, Quitting..")
 
         if hasattr(self.optimizer, 'reject_count'):
-            if hasattr(self.optimizer, 'reject') and self.optimizer.reject_count >= self.optimizer.reject:
+            if self.optimizer.reject_count > 0:
+            # To know whether the last step is rejected by the optimizer.
+            # If rejected, the scheduler also need to quit.
                 self._continual = False
                 if self.verbose:
                     print("StopOnPlateau: Maximum rejected steps reached, Quitting..")

--- a/pypose/optim/scheduler.py
+++ b/pypose/optim/scheduler.py
@@ -118,14 +118,16 @@ class StopOnPlateau(_Scheduler):
             >>> while scheduler.continual():
             ...     loss = optimizer.step(input)
             ...     scheduler.step(loss)
-            StopOnPlateau on step 0 Loss 9.337769e+01 --> Loss 3.502787e-05 (reduction/loss: 1.0000e+00).
-            StopOnPlateau on step 1 Loss 3.502787e-05 --> Loss 4.527339e-13 (reduction/loss: 1.0000e+00).
-            StopOnPlateau on step 2 Loss 4.527339e-13 --> Loss 7.112640e-14 (reduction/loss: 8.4290e-01).
-            StopOnPlateau on step 3 Loss 7.112640e-14 --> Loss 3.693307e-14 (reduction/loss: 4.8074e-01).
-            StopOnPlateau: Maximum patience steps reached, Quiting..
+            StopOnPlateau on step 1 Loss 9.337769e+01 --> Loss 3.502787e-05 (reduction/loss: 1.0000e+00).
+            StopOnPlateau on step 2 Loss 3.502787e-05 --> Loss 4.527339e-13 (reduction/loss: 1.0000e+00).
+            StopOnPlateau on step 3 Loss 4.527339e-13 --> Loss 7.112640e-14 (reduction/loss: 8.4290e-01).
+            StopOnPlateau on step 4 Loss 7.112640e-14 --> Loss 3.693307e-14 (reduction/loss: 4.8074e-01).
+            StopOnPlateau: Maximum patience steps reached, Quitting..
         '''
         assert self.optimizer.loss is not None, \
             'scheduler.step() should be called after optimizer.step()'
+
+        self.steps = self.steps + 1
 
         if self.verbose:
             print('StopOnPlateau on step {} Loss {:.6e} --> Loss {:.6e} '\
@@ -133,12 +135,10 @@ class StopOnPlateau(_Scheduler):
                   self.optimizer.loss, (self.optimizer.last - self.optimizer.loss) /\
                   (self.optimizer.last + 1e-31)))
 
-        self.steps = self.steps + 1
-
         if self.steps >= self.max_steps:
             self._continual = False
             if self.verbose:
-                print("StopOnPlateau: Maximum steps reached, Quiting..")
+                print("StopOnPlateau: Maximum steps reached, Quitting..")
 
         if (self.optimizer.last - self.optimizer.loss) < self.decreasing:
             self.patience_count = self.patience_count + 1
@@ -148,13 +148,13 @@ class StopOnPlateau(_Scheduler):
         if self.patience_count >= self.patience:
             self._continual = False
             if self.verbose:
-                print("StopOnPlateau: Maximum patience steps reached, Quiting..")
+                print("StopOnPlateau: Maximum patience steps reached, Quitting..")
 
         if hasattr(self.optimizer, 'reject_count'):
-            if self.optimizer.reject_count > 0:
+            if hasattr(self.optimizer, 'reject') and self.optimizer.reject_count >= self.optimizer.reject:
                 self._continual = False
                 if self.verbose:
-                    print("StopOnPlateau: Maximum rejected steps reached, Quiting..")
+                    print("StopOnPlateau: Maximum rejected steps reached, Quitting..")
 
     @torch.no_grad()
     def optimize(self, input, target=None, weight=None):
@@ -190,11 +190,11 @@ class StopOnPlateau(_Scheduler):
             >>>                     patience=3, decreasing=1e-3, verbose=True)
             ...
             >>> scheduler.optimize(input=input)
-            StopOnPlateau on step 0 Loss 5.199298e+01 --> Loss 8.425808e-06 (reduction/loss: 1.0000e+00).
-            StopOnPlateau on step 1 Loss 8.425808e-06 --> Loss 3.456247e-13 (reduction/loss: 1.0000e+00).
-            StopOnPlateau on step 2 Loss 3.456247e-13 --> Loss 1.525355e-13 (reduction/loss: 5.5867e-01).
-            StopOnPlateau on step 3 Loss 1.525355e-13 --> Loss 6.769275e-14 (reduction/loss: 5.5622e-01).
-            StopOnPlateau: Maximum patience steps reached, Quiting..
+            StopOnPlateau on step 1 Loss 5.199298e+01 --> Loss 8.425808e-06 (reduction/loss: 1.0000e+00).
+            StopOnPlateau on step 2 Loss 8.425808e-06 --> Loss 3.456247e-13 (reduction/loss: 1.0000e+00).
+            StopOnPlateau on step 3 Loss 3.456247e-13 --> Loss 1.525355e-13 (reduction/loss: 5.5867e-01).
+            StopOnPlateau on step 4 Loss 1.525355e-13 --> Loss 6.769275e-14 (reduction/loss: 5.5622e-01).
+            StopOnPlateau: Maximum patience steps reached, Quitting..
         '''
         while self.continual():
             loss = self.optimizer.step(input, target, weight)

--- a/pypose/optim/scheduler.py
+++ b/pypose/optim/scheduler.py
@@ -153,7 +153,7 @@ class StopOnPlateau(_Scheduler):
         if hasattr(self.optimizer, 'reject_count'):
             if self.optimizer.reject_count > 0:
             # To know whether the last step is rejected by the optimizer.
-            # If rejected, the scheduler also need to quit.
+            # If rejected, the scheduler also needs to quit.
                 self._continual = False
                 if self.verbose:
                     print("StopOnPlateau: Maximum rejected steps reached, Quitting..")


### PR DESCRIPTION
This pull request updates the `StopOnPlateau` scheduler logic in `pypose/optim/scheduler.py` to improve step counting, correct log messages, and clarify quitting conditions. The changes primarily focus on making the scheduler's behavior and output more accurate and user-friendly.

Key improvements include:

**Step Counting and Example Output:**
- Adjusted the step indexing in both the `step` and `optimize` methods so that example outputs now start from step 1 instead of 0, providing more intuitive and consistent logging. [[1]](diffhunk://#diff-d04f1dfee09e461a9b02d07b2c6cec70ab87c56f2d2e66bb7dfabfbad96cb63aL121-R141) [[2]](diffhunk://#diff-d04f1dfee09e461a9b02d07b2c6cec70ab87c56f2d2e66bb7dfabfbad96cb63aL193-R199)

**Logging and Messaging:**
- Corrected the spelling of "Quitting" in all log messages (previously "Quiting") for better professionalism and clarity. [[1]](diffhunk://#diff-d04f1dfee09e461a9b02d07b2c6cec70ab87c56f2d2e66bb7dfabfbad96cb63aL121-R141) [[2]](diffhunk://#diff-d04f1dfee09e461a9b02d07b2c6cec70ab87c56f2d2e66bb7dfabfbad96cb63aL151-R159) [[3]](diffhunk://#diff-d04f1dfee09e461a9b02d07b2c6cec70ab87c56f2d2e66bb7dfabfbad96cb63aL193-R199)
- Improved log messages to accurately reflect when the scheduler stops due to reaching maximum steps, patience, or rejected steps.

**Code Structure and Clarity:**
- Reordered the increment of `self.steps` to occur before logging, ensuring that the step number in logs matches the actual operation step.
- Added comments to clarify the logic for quitting when the optimizer rejects a step, making the code easier to understand for future maintainers.