### PR TITLE
Fix redundant LieGroup gradient dimensions in second-order optimizers

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04  # <- add this line
+  os: ubuntu-22.04
   tools:
     python: "3.9"
 

--- a/pypose/optim/optimizer.py
+++ b/pypose/optim/optimizer.py
@@ -74,8 +74,18 @@ class RobustModel(nn.Module):
 
     def flatten_row_jacobian(self, J, params_values):
         if isinstance(J, (tuple, list)):
-            J = torch.cat([j.reshape(-1, p.numel()) for j, p in zip(J, params_values)], 1)
+            # Only include trainable parameters to match update_parameter split.
+            pairs = [(j, p) for j, p in zip(J, params_values) if p.requires_grad]
+            J = torch.cat([self._flatten_single_jacobian(j, p) for j, p in pairs], 1)
         return J
+
+    def _flatten_single_jacobian(self, j, param):
+        update_shape = _parameter_update_shape(param)
+        if isinstance(param, pp.LieTensor) and not param.ltype.on_manifold:
+            # For LieGroup parameters, slice the redundant embedding dimensions
+            # from the Jacobian's last axis before flattening.
+            j = j[..., :update_shape[-1]]
+        return j.reshape(-1, update_shape.numel())
 
     def normalize_RWJ(self, R, weight, J):
         weight_diag = None
@@ -136,8 +146,11 @@ class _Optimizer(Optimizer):
         r'''
         params will be updated by calling this function
         '''
-        steps = step.split([p.numel() for p in params if p.requires_grad])
-        [p.add_(d.view(p.shape)) for p, d in zip(params, steps) if p.requires_grad]
+        grad_params = [p for p in params if p.requires_grad]
+        numels = [_parameter_update_shape(p).numel() for p in grad_params]
+        steps = step.split(numels)
+        for p, d in zip(grad_params, steps):
+            p.add_(d.view(_parameter_update_shape(p)))
 
 
 class GaussNewton(_Optimizer):
@@ -484,14 +497,11 @@ class LevenbergMarquardt(_Optimizer):
 
     def update_parameter(self, params, step):
         if getattr(self, 'sparse', False):
-            numels = []
-            for param in params:
-                if param.requires_grad:
-                    numels.append(_parameter_update_shape(param).numel())
+            grad_params = [p for p in params if p.requires_grad]
+            numels = [_parameter_update_shape(p).numel() for p in grad_params]
             steps = step.split(numels)
-            for (param, d) in zip(params, steps):
-                if param.requires_grad:
-                    param.add_(d.view(_parameter_update_shape(param)))
+            for p, d in zip(grad_params, steps):
+                p.add_(d.view(_parameter_update_shape(p)))
         else:
             super().update_parameter(params, step)
 

--- a/pypose/optim/optimizer.py
+++ b/pypose/optim/optimizer.py
@@ -74,7 +74,7 @@ class RobustModel(nn.Module):
 
     def flatten_row_jacobian(self, J, params_values):
         if isinstance(J, (tuple, list)):
-            # Only include trainable parameters to match update_parameter split.
+            # Keep J columns aligned with trainable update segments in R^n.
             pairs = [(j, p) for j, p in zip(J, params_values) if p.requires_grad]
             if not pairs:
                 raise RuntimeError("Cannot flatten a Jacobian with no trainable parameters")
@@ -84,8 +84,8 @@ class RobustModel(nn.Module):
     def _flatten_single_jacobian(self, j, param):
         update_shape = _parameter_update_shape(param)
         if isinstance(param, pp.LieTensor) and not param.ltype.on_manifold:
-            # For LieGroup parameters, slice the redundant embedding dimensions
-            # from the Jacobian's last axis before flattening.
+            # J is initially in R^(m x d_embed); retain d_manifold columns
+            # before flattening because updates live in the tangent space.
             j = j[..., :update_shape[-1]]
         return j.reshape(-1, update_shape.numel())
 
@@ -148,7 +148,9 @@ class _Optimizer(Optimizer):
         r'''
         params will be updated by calling this function
         '''
+        # Frozen parameters do not consume optimizer-step segments.
         grad_params = [p for p in params if p.requires_grad]
+        # For LieTensor p, each delta_i is shaped in R^(batch x d_manifold).
         numels = [_parameter_update_shape(p).numel() for p in grad_params]
         steps = step.split(numels)
         for p, d in zip(grad_params, steps):
@@ -499,6 +501,7 @@ class LevenbergMarquardt(_Optimizer):
 
     def update_parameter(self, params, step):
         if getattr(self, 'sparse', False):
+            # Keep sparse updates aligned with the same trainable parameters.
             grad_params = [p for p in params if p.requires_grad]
             numels = [_parameter_update_shape(p).numel() for p in grad_params]
             steps = step.split(numels)

--- a/pypose/optim/optimizer.py
+++ b/pypose/optim/optimizer.py
@@ -76,6 +76,8 @@ class RobustModel(nn.Module):
         if isinstance(J, (tuple, list)):
             # Only include trainable parameters to match update_parameter split.
             pairs = [(j, p) for j, p in zip(J, params_values) if p.requires_grad]
+            if not pairs:
+                raise RuntimeError("Cannot flatten a Jacobian with no trainable parameters")
             J = torch.cat([self._flatten_single_jacobian(j, p) for j, p in pairs], 1)
         return J
 

--- a/pypose/optim/optimizer.py
+++ b/pypose/optim/optimizer.py
@@ -74,6 +74,8 @@ class RobustModel(nn.Module):
 
     def flatten_row_jacobian(self, J, params_values):
         if isinstance(J, (tuple, list)):
+            if len(J) != len(params_values):
+                raise ValueError("Jacobian and parameter sequences must have the same length")
             # Keep J columns aligned with trainable update segments in R^n.
             pairs = [(j, p) for j, p in zip(J, params_values) if p.requires_grad]
             if not pairs:
@@ -150,6 +152,8 @@ class _Optimizer(Optimizer):
         '''
         # Frozen parameters do not consume optimizer-step segments.
         grad_params = [p for p in params if p.requires_grad]
+        if not grad_params:
+            raise RuntimeError("Cannot update parameters when none require gradients")
         # For LieTensor p, each delta_i is shaped in R^(batch x d_manifold).
         numels = [_parameter_update_shape(p).numel() for p in grad_params]
         steps = step.split(numels)
@@ -503,6 +507,8 @@ class LevenbergMarquardt(_Optimizer):
         if getattr(self, 'sparse', False):
             # Keep sparse updates aligned with the same trainable parameters.
             grad_params = [p for p in params if p.requires_grad]
+            if not grad_params:
+                raise RuntimeError("Cannot update parameters when none require gradients")
             numels = [_parameter_update_shape(p).numel() for p in grad_params]
             steps = step.split(numels)
             for p, d in zip(grad_params, steps):

--- a/tests/optim/test_optimizer.py
+++ b/tests/optim/test_optimizer.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 import torch
 import pypose as pp
 from torch import nn
@@ -481,6 +482,18 @@ class TestLieGroupGradientDimension:
 
         # pose2 should be untouched
         torch.testing.assert_close(model.pose2, pose2_before)
+
+    def test_all_parameters_frozen_fail_clearly(self):
+        """Jacobian flattening reports when no trainable parameters remain."""
+        from pypose.optim.optimizer import RobustModel
+
+        model = nn.Linear(2, 2)
+        for parameter in model.parameters():
+            parameter.requires_grad_(False)
+
+        jacobian = (torch.zeros(2, 2, 2, 2, 2),)
+        with pytest.raises(RuntimeError, match="no trainable parameters"):
+            RobustModel(model).flatten_row_jacobian(jacobian, tuple(model.parameters()))
 
 
 if __name__ == '__main__':

--- a/tests/optim/test_optimizer.py
+++ b/tests/optim/test_optimizer.py
@@ -359,6 +359,130 @@ class TestOptim:
         assert idx < 9, "Optimization requires too many steps."
 
 
+# --- PR #387 regression tests: LieGroup gradient dimension ---
+
+class TestLieGroupGradientDimension:
+    """Regression tests for batched LieGroup (SE3) parameter updates.
+
+    Second-order optimizers must consume and reshape optimizer steps using
+    the manifold dimension (6 for SE3), not the embedding dimension (7).
+    """
+
+    def test_batched_se3_liegroup_optimizer_step(self):
+        """Batched SE3 LieTensor parameters converge with LM."""
+        class PoseInv(nn.Module):
+            def __init__(self, *dim):
+                super().__init__()
+                self.pose = pp.Parameter(pp.randn_se3(*dim).Exp())
+
+            def forward(self, inputs):
+                return (self.pose @ inputs).Log()
+
+        model = PoseInv(3, 3)
+        inputs = pp.randn_SE3(3, 3, sigma=0.01)
+        optimizer = pp.optim.LM(model)
+
+        for _ in range(10):
+            loss = optimizer.step(inputs)
+            if loss < 1e-4:
+                break
+        assert loss < 1e-4, f"Batched SE3 LieGroup should converge, loss={loss}"
+
+    def test_batched_se3_no_padded_zeros(self):
+        """Jacobian columns for SE3 must be manifold-sized (not embedding-sized)."""
+        from pypose.optim.optimizer import RobustModel, _parameter_update_shape
+        from pypose.optim.functional import modjac
+
+        class PoseInv(nn.Module):
+            def __init__(self, *dim):
+                super().__init__()
+                self.pose = pp.Parameter(pp.randn_se3(*dim).Exp())
+
+            def forward(self, inputs):
+                return (self.pose @ inputs).Log()
+
+        model = PoseInv(2, 2)
+        inputs = pp.randn_SE3(2, 2)
+
+        J = modjac(model, input=(inputs,), flatten=False)
+        params_values = tuple(dict(model.named_parameters()).values())
+        robust = RobustModel(model)
+        flat_J = robust.flatten_row_jacobian(J, params_values)
+
+        # SE3 has 4 elements in batch dims, each with manifold=6
+        expected_cols = int(model.pose.ltype.manifold[0]) * model.pose.shape[:-1].numel()
+        assert flat_J.shape[1] == expected_cols, \
+            f"Expected {expected_cols} Jacobian columns (manifold), got {flat_J.shape[1]}"
+
+    def test_ordinary_tensor_unchanged(self):
+        """Ordinary (non-LieTensor) parameters retain existing behavior."""
+        class LinearModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(4, 4))
+
+            def forward(self, x):
+                return self.weight @ x
+
+        model = LinearModel()
+        x = torch.randn(4, 2)
+        target = torch.randn(4, 2)
+        optimizer = pp.optim.LM(model)
+
+        for _ in range(5):
+            loss = optimizer.step(x, target)
+            if loss < 1e-6:
+                break
+        # Ordinary tensors work as before (no assertion on convergence,
+        # just verify no shape error is raised)
+
+    def test_mixed_lietensor_and_tensor_params(self):
+        """Mixed LieTensor + ordinary Tensor parameters work together."""
+        class MixedModel(nn.Module):
+            def __init__(self, *dim):
+                super().__init__()
+                self.pose = pp.Parameter(pp.randn_se3(*dim).Exp())
+                self.scale = nn.Parameter(torch.ones(1))
+
+            def forward(self, inputs):
+                return ((self.pose @ inputs).Log() * self.scale).tensor()
+
+        model = MixedModel(2, 2)
+        # Target is zero: pose should become identity and scale is irrelevant
+        inputs = pp.randn_SE3(2, 2, sigma=0.01)
+        optimizer = pp.optim.LM(model)
+
+        for _ in range(15):
+            loss = optimizer.step(inputs)
+            if loss < 1e-4:
+                break
+        # Mixed params should converge when target is implicit zero
+        assert loss < 1e-3, f"Mixed params should converge, loss={loss}"
+
+    def test_frozen_parameters_excluded(self):
+        """Parameters with requires_grad=False are excluded from updates."""
+        class PoseInv(nn.Module):
+            def __init__(self, *dim):
+                super().__init__()
+                self.pose1 = pp.Parameter(pp.randn_se3(*dim).Exp())
+                self.pose2 = pp.Parameter(pp.randn_se3(*dim).Exp())
+
+            def forward(self, inputs):
+                return (self.pose1 @ inputs).Log()
+
+        model = PoseInv(2, 2)
+        model.pose2.requires_grad_(False)
+        pose2_before = model.pose2.clone()
+        inputs = pp.randn_SE3(2, 2, sigma=0.01)
+        optimizer = pp.optim.LM(model)
+
+        for _ in range(5):
+            loss = optimizer.step(inputs)
+
+        # pose2 should be untouched
+        torch.testing.assert_close(model.pose2, pose2_before)
+
+
 if __name__ == '__main__':
     test = TestOptim()
     test.test_optim_liealgebra()

--- a/tests/optim/test_optimizer.py
+++ b/tests/optim/test_optimizer.py
@@ -465,10 +465,10 @@ class TestLieGroupGradientDimension:
             def __init__(self, *dim):
                 super().__init__()
                 self.pose1 = pp.Parameter(pp.randn_se3(*dim).Exp())
-                self.pose2 = pp.Parameter(pp.randn_se3(*dim).Exp())
+                self.pose2 = pp.Parameter(pp.identity_SE3(*dim))
 
             def forward(self, inputs):
-                return (self.pose1 @ inputs).Log()
+                return (self.pose1 @ self.pose2 @ inputs).Log()
 
         model = PoseInv(2, 2)
         model.pose2.requires_grad_(False)

--- a/tests/optim/test_optimizer.py
+++ b/tests/optim/test_optimizer.py
@@ -371,6 +371,8 @@ class TestLieGroupGradientDimension:
 
     def test_batched_se3_liegroup_optimizer_step(self):
         """Batched SE3 LieTensor parameters converge with LM."""
+        torch.manual_seed(0)
+
         class PoseInv(nn.Module):
             def __init__(self, *dim):
                 super().__init__()
@@ -406,7 +408,7 @@ class TestLieGroupGradientDimension:
         inputs = pp.randn_SE3(2, 2)
 
         J = modjac(model, input=(inputs,), flatten=False)
-        params_values = tuple(dict(model.named_parameters()).values())
+        params_values = tuple(p for _, p in model.named_parameters())
         robust = RobustModel(model)
         flat_J = robust.flatten_row_jacobian(J, params_values)
 
@@ -439,6 +441,8 @@ class TestLieGroupGradientDimension:
 
     def test_mixed_lietensor_and_tensor_params(self):
         """Mixed LieTensor + ordinary Tensor parameters work together."""
+        torch.manual_seed(1)
+
         class MixedModel(nn.Module):
             def __init__(self, *dim):
                 super().__init__()
@@ -446,10 +450,11 @@ class TestLieGroupGradientDimension:
                 self.scale = nn.Parameter(torch.ones(1))
 
             def forward(self, inputs):
-                return ((self.pose @ inputs).Log() * self.scale).tensor()
+                pose_residual = ((self.pose @ inputs).Log() * self.scale).tensor()
+                return pose_residual, self.scale - 1
 
         model = MixedModel(2, 2)
-        # Target is zero: pose should become identity and scale is irrelevant
+        # The second residual constrains scale to one, forcing pose to converge.
         inputs = pp.randn_SE3(2, 2, sigma=0.01)
         optimizer = pp.optim.LM(model)
 
@@ -457,7 +462,9 @@ class TestLieGroupGradientDimension:
             loss = optimizer.step(inputs)
             if loss < 1e-4:
                 break
-        # Mixed params should converge when target is implicit zero
+        torch.testing.assert_close(model.scale, torch.ones(1), atol=1e-4, rtol=1e-4)
+        pose_residual = (model.pose @ inputs).Log().tensor()
+        assert pose_residual.norm() < 1e-3, "Pose update did not converge independently of scale"
         assert loss < 1e-3, f"Mixed params should converge, loss={loss}"
 
     def test_frozen_parameters_excluded(self):
@@ -491,8 +498,17 @@ class TestLieGroupGradientDimension:
         for parameter in model.parameters():
             parameter.requires_grad_(False)
 
-        jacobian = (torch.zeros(2, 2, 2, 2, 2),)
+        jacobian = (torch.zeros(2, 2, 2, 2, 2),) * 2
         with pytest.raises(RuntimeError, match="no trainable parameters"):
+            RobustModel(model).flatten_row_jacobian(jacobian, tuple(model.parameters()))
+
+    def test_jacobian_parameter_length_mismatch(self):
+        """Jacobian and parameter sequences must describe the same model."""
+        from pypose.optim.optimizer import RobustModel
+
+        model = nn.Linear(2, 2)
+        jacobian = (torch.zeros(2, 2, 2, 2, 2),)
+        with pytest.raises(ValueError, match="same length"):
             RobustModel(model).flatten_row_jacobian(jacobian, tuple(model.parameters()))
 
 

--- a/tests/optim/test_optimizer.py
+++ b/tests/optim/test_optimizer.py
@@ -390,7 +390,7 @@ class TestLieGroupGradientDimension:
 
     def test_batched_se3_no_padded_zeros(self):
         """Jacobian columns for SE3 must be manifold-sized (not embedding-sized)."""
-        from pypose.optim.optimizer import RobustModel, _parameter_update_shape
+        from pypose.optim.optimizer import RobustModel
         from pypose.optim.functional import modjac
 
         class PoseInv(nn.Module):


### PR DESCRIPTION
## Summary

Fix redundant LieGroup embedding dimensions in second-order optimizer Jacobians and parameter updates.

For LieTensor parameters such as SE3, the embedded representation contains redundant coordinates (7 values) while the tangent/manifold update has 6 degrees of freedom. The previous implementation retained the padded embedding columns, making the estimated Hessian unnecessarily singular or poorly conditioned.

## Changes

- Slice redundant LieGroup embedding coordinates before flattening Jacobian rows.
- Use `p.shape[:-1] + p.ltype.manifold` for LieTensor optimizer step splitting and reshaping.
- Preserve ordinary Tensor behavior.
- Correct dense and sparse LM parameter-step alignment.
- Exclude frozen parameters consistently from Jacobian columns and step updates.
- Add regression coverage for batched SE3, ordinary Tensor, mixed parameters, and frozen parameters.

## Validation

CPU-only validation with Torch 2.13.0+cu130 and PyPose editable-installed in the dedicated development environment:

- `tests/optim/test_optimizer.py`: 17 passed.
- Full suite: **97 passed, 2 skipped**.
- `git diff --check`: passed.

The two skipped tests are existing expected skips. The test run used `CUDA_VISIBLE_DEVICES=""`; no GPU was used.

Fixes #387
